### PR TITLE
add optax optimizer, and make examples directory

### DIFF
--- a/examples/gauss_optimize.py
+++ b/examples/gauss_optimize.py
@@ -1,0 +1,35 @@
+
+# MAP estimate for multivariate Diagonal Gaussian 
+
+import jax.numpy as jnp
+from jax import random
+from sgmcmcjax.optimizer import build_adam_optimizer
+#from . sgmcmc.optimizer import build_adam_optimizer, build_optax_optimizer
+import optax
+
+def loglikelihood(theta, x):
+    return -0.5*jnp.dot(x-theta, x-theta)
+
+def logprior(theta):
+    return -0.5*jnp.dot(theta, theta)*0.01
+
+# generate dataset
+N, D = 10_000, 100
+key = random.PRNGKey(0)
+mu_true = random.normal(key, (D,))
+X_data = random.normal(key, shape=(N, D)) + mu_true
+
+# Adam
+batch_size = int(0.1*N)
+dt = 1e-2
+#optimizer = optimizer.build_adam_optimizer(dt, loglikelihood, logprior, (X_data,), batch_size)
+optimizer = build_adam_optimizer(dt, loglikelihood, logprior, (X_data,), batch_size)
+
+Nsamples = 10_000
+params, log_post_list = optimizer(key, Nsamples, jnp.zeros(D))
+print(log_post_list.shape)
+print(params.shape)
+assert jnp.allclose(params, mu_true, atol=1e-1)
+print('test passed')
+
+

--- a/examples/gauss_sample_sgld.py
+++ b/examples/gauss_sample_sgld.py
@@ -1,0 +1,35 @@
+
+# Sample from multivariate Diagonal Gaussian using SGLD
+
+import jax.numpy as jnp
+from jax import random
+from sgmcmcjax.samplers import build_sgld_sampler
+
+
+def loglikelihood(theta, x):
+    return -0.5*jnp.dot(x-theta, x-theta)
+
+def logprior(theta):
+    return -0.5*jnp.dot(theta, theta)*0.01
+
+# generate dataset
+N, D = 10_000, 100
+key = random.PRNGKey(0)
+mu_true = random.normal(key, (D,))
+X_data = random.normal(key, shape=(N, D)) + mu_true
+
+# build sampler
+batch_size = int(0.1*N)
+dt = 1e-5
+sampler = build_sgld_sampler(dt, loglikelihood, logprior, (X_data,), batch_size)
+
+# run sampler
+Nsamples = 10_000
+samples = sampler(key, Nsamples, jnp.zeros(D))
+
+# test
+print(samples.shape)
+mu_est = jnp.mean(samples, axis=0)
+print(mu_est.shape)
+assert jnp.allclose(mu_est, mu_true, atol=1e-1)
+print('test passed')

--- a/sgmcmcjax/optimizer.py
+++ b/sgmcmcjax/optimizer.py
@@ -3,6 +3,7 @@ from jax.tree_util import tree_map
 from jax.experimental.optimizers import adam
 from jax import jit, lax, random
 import jax.numpy as jnp
+import optax
 
 from .gradient_estimation import build_gradient_estimation_fn
 from .util import progress_bar_scan, build_grad_log_post
@@ -29,3 +30,27 @@ def build_adam_optimizer(dt: float, loglikelihood: Callable, logprior: Callable,
         (_, state_opt), logpost_array = lax.scan(body_pbar, (key, state), jnp.arange(Niters))
         return get_params(state_opt), logpost_array
     return run_adam
+
+
+
+def build_optax_optimizer(optimizer: optax.GradientTransformation, loglikelihood: Callable, logprior: Callable, data: Tuple, batch_size: int) -> Callable:
+    grad_log_post = build_grad_log_post(loglikelihood, logprior, data, with_val=True)
+    estimate_gradient, _ = build_gradient_estimation_fn(grad_log_post, data, batch_size)
+ 
+    @jit
+    def body(carry, i):
+        key, state, params = carry
+        key, subkey = random.split(key)
+        (lp_val, param_grad), _ = estimate_gradient(i, subkey, params)
+        neg_param_grad = tree_map(lambda x: -x, param_grad)
+        updates, state = optimizer.update(neg_param_grad, state)
+        params = optax.apply_updates(params, updates)
+        return (key, state, params), lp_val
+
+
+    def run_optimizer(key, Niters, params):
+        state = optimizer.init(params)
+        body_pbar = progress_bar_scan(Niters)(body)
+        (key, state, params), logpost_array = lax.scan(body_pbar, (key, state, params), jnp.arange(Niters))
+        return params, logpost_array
+    return run_optimizer


### PR DESCRIPTION
- I generalized `build_adam_optimizer` to make `build_optax_optimizer` that takes in any optax optimizer.
- I created examples subdirectory
- I added `examples/gauss_sample_sgld.py` which is basically the same as your 'quick start' demo (sample from D-dim. Gaussian)
- I added `examples/gauss_optimize.py` which is similar to `gauss_sample_sgld` but uses the adam optimizer
- I was not able to make `gauss_optimize.py` test my new `optax_optimizer` because I get the `attempted relative import with no known parent package` error :(